### PR TITLE
Fix void function return errors

### DIFF
--- a/lib/presentation/pages/assistant/widgets/query_input_widget.dart
+++ b/lib/presentation/pages/assistant/widgets/query_input_widget.dart
@@ -133,7 +133,7 @@ class _QueryInputWidgetState extends State<QueryInputWidget> with TickerProvider
                       Expanded(
                         child: RawKeyboardListener(
                           focusNode: FocusNode(),
-                          onKey: (event) {
+                          onKey: (RawKeyEvent event): KeyEventResult {
                             if (event is RawKeyDownEvent) {
                               if (event.logicalKey == LogicalKeyboardKey.enter) {
                                 if (event.isShiftPressed) {


### PR DESCRIPTION
Add explicit `KeyEventResult` return type to `RawKeyboardListener.onKey` callback to resolve 'Can't return a value from a void function' error.